### PR TITLE
fix: correct dates and typo in dol-holy-days.json

### DIFF
--- a/json/readings/dol-holy-days.json
+++ b/json/readings/dol-holy-days.json
@@ -1,806 +1,806 @@
 [
-	{
-		"day": "Nov 10",
-		"title": "Saint Andrew the Apostle",
-		"psalms": {
-			"morning": [
-				"34"
-			],
-			"evening": [
-				"96",
-				"100"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Isa 49:1–6",
-				"second": "1 Cor 4:1–16"
-			},
-			"evening": {
-				"first": "Isa 55:1–5",
-				"second": "John 1:35–42"
-			}
-		}
-	},
-	{
-		"day": "Dec 21",
-		"title": "Saint Thomas the Apostle",
-		"psalms": {
-			"morning": [
-				"23",
-				"121"
-			],
-			"evening": [
-				"27"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Job 42:1–6",
-				"second": "1 Pet 1:3–9"
-			},
-			"evening": {
-				"first": "Isa 43:8–13",
-				"second": "John 14:1–7"
-			}
-		}
-	},
-	{
-		"day": "Dec 26",
-		"title": "Saint Stephen, Deacon and Martyr",
-		"psalms": {
-			"morning": [
-				"28",
-				"30"
-			],
-			"evening": [
-				"118"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "2 Chr 24:17–22",
-				"second": "Acts 6:1–7"
-			},
-			"evening": {
-				"first": "Wis 4:7–15",
-				"second": "Acts 7:59–8:8"
-			}
-		}
-	},
-	{
-		"day": "Dec 27",
-		"title": "Saint John, Apostle and Evangelist",
-		"psalms": {
-			"morning": [
-				"97",
-				"98"
-			],
-			"evening": [
-				"145"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Prov 8:22–30",
-				"second": "John 13:20–35"
-			},
-			"evening": {
-				"first": "Isa 44:1–8",
-				"second": "1 John 5:1–12"
-			}
-		}
-	},
-	{
-		"day": "Dec 28",
-		"title": "The Holy Innocents",
-		"psalms": {
-			"morning": [
-				"2",
-				"26"
-			],
-			"evening": [
-				"19",
-				"126"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Isa 49:13–23",
-				"second": "Matt 18:1–14"
-			},
-			"evening": {
-				"first": "Isa 54:1–13",
-				"second": "Mark 10:13–16"
-			}
-		}
-	},
-	{
-		"day": "Jan 18",
-		"title": "The Confession of Saint Peter the Apostle",
-		"psalms": {
-			"morning": [
-				"66",
-				"67"
-			],
-			"evening": [
-				"118"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Ezek 3:4–11",
-				"second": "Acts 10:34–44"
-			},
-			"evening": {
-				"first": "Ezek 34:11–16",
-				"second": "John 21:15–22"
-			}
-		}
-	},
-	{
-		"day": "Jan 25",
-		"title": "The Conversion of Saint Paul the Apostle",
-		"psalms": {
-			"morning": [
-				"19"
-			],
-			"evening": [
-				"119:89–12"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Isa 45:18–25",
-				"second": "Phil 3:4b–11"
-			},
-			"evening": {
-				"first": "Sir 39:1–10",
-				"second": "Acts 9:1–22"
-			}
-		}
-	},
-	{
-		"day": "Feb 1",
-		"title": "Eve of the Presentation",
-		"psalms": {
-			"evening": [
-				"113",
-				"122"
-			]
-		},
-		"lessons": {
-			"evening": {
-				"first": "1 Sam 1:20–28a",
-				"second": "Rom 8:14–21"
-			}
-		}
-	},
-	{
-		"day": "Feb 2",
-		"title": "The Presentation of Our Lord Jesus Christ in the Temple",
-		"psalms": {
-			"morning": [
-				"42",
-				"43"
-			],
-			"evening": [
-				"48",
-				"87"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "1 Sam 2:1–10",
-				"second": "John 8:31–36"
-			},
-			"evening": {
-				"first": "Hag 2:1–9",
-				"second": "1 John 3:1–8"
-			}
-		}
-	},
-	{
-		"day": "Feb 24",
-		"title": "Saint Matthias the Apostle",
-		"psalms": {
-			"morning": [
-				"80"
-			],
-			"evening": [
-				"33"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "1 Sam 16:1–13",
-				"second": "1 John 2:18–25"
-			},
-			"evening": {
-				"first": "1 Sam 12:1–5",
-				"second": "Acts 20:17–35"
-			}
-		}
-	},
-	{
-		"day": "Mar 19",
-		"title": "Saint Joseph",
-		"psalms": {
-			"morning": [
-				"132"
-			],
-			"evening": [
-				"34"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Isa 63:7–16",
-				"second": "Matt 1:18–25"
-			},
-			"evening": {
-				"first": "2 Chr 6:12–17",
-				"second": "Eph 3:14–21"
-			}
-		}
-	},
-	{
-		"day": "Mar 24",
-		"title": "Eve of the Annunciation",
-		"psalms": {
-			"evening": [
-				"8",
-				"138"
-			]
-		},
-		"lessons": {
-			"evening": {
-				"first": "Gen 3:1–15",
-				"second": "Eph 3:14–21"
-			}
-		}
-	},
-	{
-		"day": "Mar 25",
-		"title": "The Annuciation of Our Lord Jesus Christ to Mary",
-		"psalms": {
-			"morning": [
-				"85",
-				"87"
-			],
-			"evening": [
-				"110:1–5(6–7)",
-				"132"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Isa 52:7–12",
-				"second": "Heb 2:5–10"
-			},
-			"evening": {
-				"first": "Wis 9:1–12",
-				"second": "John 1:9–14"
-			}
-		}
-	},
-	{
-		"day": "Apr 25",
-		"title": "Saint Mark the Evangelist",
-		"psalms": {
-			"morning": [
-				"145"
-			],
-			"evening": [
-				"67",
-				"96"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Sir 2:1–11",
-				"second": "Acts 12:25–13:3"
-			},
-			"evening": {
-				"first": "Isa 62:6–12",
-				"second": "2 Tim 4:1–11"
-			}
-		}
-	},
-	{
-		"day": "May 1",
-		"title": "Saint Philip and Saint James, Apostles",
-		"psalms": {
-			"morning": [
-				"119:137–160"
-			],
-			"evening": [
-				"139"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Job 23:1–12",
-				"second": "John 1:42–51"
-			},
-			"evening": {
-				"first": "Prov 4:7–8",
-				"second": "John 12:20–26"
-			}
-		}
-	},
-	{
-		"day": "May 30",
-		"title": "Eve of the Visitation",
-		"psalms": {
-			"evening": [
-				"146",
-				"147"
-			]
-		},
-		"lessons": {
-			"evening": {
-				"first": "Isa 11:1–10",
-				"second": "Heb 2:11–18"
-			}
-		}
-	},
-	{
-		"day": "May 31",
-		"title": "The Visitation of Mary to Elizabeth",
-		"psalms": {
-			"morning": [
-				"72"
-			],
-			"evening": [
-				"146",
-				"147"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "1 Sam 1:1–20",
-				"second": "Heb 3:1–6"
-			},
-			"evening": {
-				"first": "Zech 2:10–13",
-				"second": "John 3:25–30"
-			}
-		}
-	},
-	{
-		"day": "Jun 11",
-		"title": "Saint Barnabas the Apostle",
-		"psalms": {
-			"morning": [
-				"15",
-				"67"
-			],
-			"evening": [
-				"19",
-				"146"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Sir 31:3–11",
-				"second": "Acts 4:32–37"
-			},
-			"evening": {
-				"first": "Job 29:1–16",
-				"second": "Acts 9:26–31"
-			}
-		}
-	},
-	{
-		"day": "Jun 23",
-		"title": "Eve of Saint John the Baptist",
-		"psalms": {
-			"evening": [
-				"103"
-			]
-		},
-		"lessons": {
-			"evening": {
-				"first": "Sir 48:1–11",
-				"second": "Luke 1:5–23"
-			}
-		}
-	},
-	{
-		"day": "Jun 24",
-		"title": "The Nativity of Saint John the Baptist",
-		"psalms": {
-			"morning": [
-				"82",
-				"98"
-			],
-			"evening": [
-				"80"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Mal 3:1–5",
-				"second": "John 3:22–30"
-			},
-			"evening": {
-				"first": "Mal 4:1–6",
-				"second": "Matt 11:2–19"
-			}
-		}
-	},
-	{
-		"day": "Jun 29",
-		"title": "Saint Peter and Saint Paul, Apostles",
-		"psalms": {
-			"morning": [
-				"66"
-			],
-			"evening": [
-				"97",
-				"138"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Ezek 2:1–7",
-				"second": "Acts 11:1–18"
-			},
-			"evening": {
-				"first": "Isa 49:1–6",
-				"second": "Gal 2:1–9"
-			}
-		}
-	},
-	{
-		"day": "Jul 22",
-		"title": "Saint Mary Magdalene",
-		"psalms": {
-			"morning": [
-				"116"
-			],
-			"evening": [
-				"30",
-				"149"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Zeph 3:14–20",
-				"second": "Mark 15:47–16:7"
-			},
-			"evening": {
-				"first": "Exod 15:19–21",
-				"second": "2 Cor 1:3–7"
-			}
-		}
-	},
-	{
-		"day": "Jul 25",
-		"title": "Saint James the Apostle",
-		"psalms": {
-			"morning": [
-				"34"
-			],
-			"evening": [
-				"33"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Jer 16:14–21",
-				"second": "Mark 1:14–20"
-			},
-			"evening": {
-				"first": "Jer 26:1–15",
-				"second": "Matt 10:16–32"
-			}
-		}
-	},
-	{
-		"day": "Aug 5",
-		"title": "Eve of the Transfiguration",
-		"psalms": {
-			"evening": [
-				"84"
-			]
-		},
-		"lessons": {
-			"evening": {
-				"first": "1 Kings 19:1–12",
-				"second": "2 Cor 3:1–9, 18"
-			}
-		}
-	},
-	{
-		"day": "Aug 6",
-		"title": "The Transfiguration of Our Lord Jesus Christ",
-		"psalms": {
-			"morning": [
-				"2",
-				"24"
-			],
-			"evening": [
-				"72"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Exod 24:12–18",
-				"second": "2 Cor 4:1–6"
-			},
-			"evening": {
-				"first": "Dan 7:9–10, 13–14",
-				"second": "John 12:27–36a"
-			}
-		}
-	},
-	{
-		"day": "Aug 15",
-		"title": "Saint Mary, Mother of Our Lord Jesus Christ",
-		"psalms": {
-			"morning": [
-				"113",
-				"115"
-			],
-			"evening": [
-				"45",
-				"[138]",
-				"[149]"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "1 Sam 2:1–10",
-				"second": "John 2:1–12"
-			},
-			"evening": {
-				"first": "Jer 31:1–14",
-				"altFirst": "Zech 2:10–13",
-				"second": "John 19:23–27",
-				"altSecond": "Acts 1:6–14"
-			}
-		}
-	},
-	{
-		"day": "Aug 24",
-		"title": "Saint Bartholomew the Apostle",
-		"psalms": {
-			"morning": [
-				"86"
-			],
-			"evening": [
-				"15",
-				"67"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Gen 28:10–17",
-				"second": "John 1:43–51"
-			},
-			"evening": {
-				"first": "Isa 66:1–2, 18–23",
-				"second": "1 Pet 5:1–11"
-			}
-		}
-	},
-	{
-		"day": "Sep 13",
-		"title": "Eve of Holy Cross",
-		"psalms": {
-			"evening": [
-				"46",
-				"87"
-			]
-		},
-		"lessons": {
-			"evening": {
-				"first": "1 Kgs 8:22–30",
-				"second": "Eph 2:11–22"
-			}
-		}
-	},
-	{
-		"day": "Sep 15",
-		"title": "Holy Cross Day",
-		"psalms": {
-			"morning": [
-				"66"
-			],
-			"evening": [
-				"118"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Num 21:4–9",
-				"second": "John 3:11–17"
-			},
-			"evening": {
-				"first": "Gen 3:1–15",
-				"second": "1 Pet 3:17–22"
-			}
-		}
-	},
-	{
-		"day": "Sep 21",
-		"title": "Saint Matthew, Apostle and Evangelist",
-		"psalms": {
-			"morning": [
-				"119:41–64"
-			],
-			"evening": [
-				"19",
-				"112"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Isa 8:11–20",
-				"second": "Rom 10:1–15"
-			},
-			"evening": {
-				"first": "Job 28:12–28",
-				"second": "Matt 13:44–52"
-			}
-		}
-	},
-	{
-		"day": "Sep 29",
-		"title": "Saint Michael and All Angels",
-		"psalms": {
-			"morning": [
-				"8",
-				"148"
-			],
-			"evening": [
-				"34",
-				"150",
-				"[104]"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Job 38:1–7",
-				"second": "Heb 1:1–14"
-			},
-			"evening": {
-				"first": "Dan 12:1–3",
-				"altFirst": "2 Kgs 6:8–17",
-				"second": "Mark 13:21–27",
-				"altSecond": "Rev 5:1–14"
-			}
-		}
-	},
-	{
-		"day": "Oct 18",
-		"title": "Saint Luke the Evangelist",
-		"psalms": {
-			"morning": [
-				"103"
-			],
-			"evening": [
-				"67",
-				"96"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Ezek 47:1–12",
-				"second": "Luke 1:1–4"
-			},
-			"evening": {
-				"first": "Isa 52:7–10",
-				"second": "Acts 1:1–8"
-			}
-		}
-	},
-	{
-		"day": "Oct 23",
-		"title": "Saint James of Jerusalem, Brother of Our Lord Jesus Christ",
-		"psalms": {
-			"morning": [
-				"119:145–168"
-			],
-			"evening": [
-				"122",
-				"125"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Jer 11:18–23",
-				"second": "Matt 10:16–22"
-			},
-			"evening": {
-				"first": "Isa 65:17–25",
-				"second": "Heb 12:12–24"
-			}
-		}
-	},
-	{
-		"day": "Oct 28",
-		"title": "Saint Simon and Saint Jude, Apostles",
-		"psalms": {
-			"morning": [
-				"66"
-			],
-			"evening": [
-				"116",
-				"117"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Isa 28:9–16",
-				"second": "Eph 4:1–16"
-			},
-			"evening": {
-				"first": "Isa 4:2–9",
-				"second": "John 14:15–31"
-			}
-		}
-	},
-	{
-		"day": "Oct 31",
-		"title": "Eve of All Saints",
-		"psalms": {
-			"evening": [
-				"34"
-			]
-		},
-		"lessons": {
-			"evening": {
-				"first": "Wis 3:1–9",
-				"second": "Rev 19:1, 4–10"
-			}
-		}
-	},
-	{
-		"day": "Nov 1",
-		"title": "All Saints' Day",
-		"psalms": {
-			"morning": [
-				"111",
-				"112"
-			],
-			"evening": [
-				"148",
-				"150"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "2 Esd 2:42–47",
-				"second": "Heb 11:32–12:2"
-			},
-			"evening": {
-				"first": "Wis 5:1–5, 14–16",
-				"second": "Rev 21:1–4, 22–22:5"
-			}
-		}
-	},
-	{
-		"title": "Thanksgiving Day",
-		"psalms": {
-			"morning": [
-				"147"
-			],
-			"evening": [
-				"145"
-			]
-		},
-		"lessons": {
-			"morning": {
-				"first": "Deut 26:1–11",
-				"second": "John 6:26–35"
-			},
-			"evening": {
-				"first": "Joel 2:21–27",
-				"second": "1 Thess 5:12–24"
-			}
-		}
-	}
+  {
+    "day": "Nov 30",
+    "title": "Saint Andrew the Apostle",
+    "psalms": {
+      "morning": [
+        "34"
+      ],
+      "evening": [
+        "96",
+        "100"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Isa 49:1\u20136",
+        "second": "1 Cor 4:1\u201316"
+      },
+      "evening": {
+        "first": "Isa 55:1\u20135",
+        "second": "John 1:35\u201342"
+      }
+    }
+  },
+  {
+    "day": "Dec 21",
+    "title": "Saint Thomas the Apostle",
+    "psalms": {
+      "morning": [
+        "23",
+        "121"
+      ],
+      "evening": [
+        "27"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Job 42:1\u20136",
+        "second": "1 Pet 1:3\u20139"
+      },
+      "evening": {
+        "first": "Isa 43:8\u201313",
+        "second": "John 14:1\u20137"
+      }
+    }
+  },
+  {
+    "day": "Dec 26",
+    "title": "Saint Stephen, Deacon and Martyr",
+    "psalms": {
+      "morning": [
+        "28",
+        "30"
+      ],
+      "evening": [
+        "118"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "2 Chr 24:17\u201322",
+        "second": "Acts 6:1\u20137"
+      },
+      "evening": {
+        "first": "Wis 4:7\u201315",
+        "second": "Acts 7:59\u20138:8"
+      }
+    }
+  },
+  {
+    "day": "Dec 27",
+    "title": "Saint John, Apostle and Evangelist",
+    "psalms": {
+      "morning": [
+        "97",
+        "98"
+      ],
+      "evening": [
+        "145"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Prov 8:22\u201330",
+        "second": "John 13:20\u201335"
+      },
+      "evening": {
+        "first": "Isa 44:1\u20138",
+        "second": "1 John 5:1\u201312"
+      }
+    }
+  },
+  {
+    "day": "Dec 28",
+    "title": "The Holy Innocents",
+    "psalms": {
+      "morning": [
+        "2",
+        "26"
+      ],
+      "evening": [
+        "19",
+        "126"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Isa 49:13\u201323",
+        "second": "Matt 18:1\u201314"
+      },
+      "evening": {
+        "first": "Isa 54:1\u201313",
+        "second": "Mark 10:13\u201316"
+      }
+    }
+  },
+  {
+    "day": "Jan 18",
+    "title": "The Confession of Saint Peter the Apostle",
+    "psalms": {
+      "morning": [
+        "66",
+        "67"
+      ],
+      "evening": [
+        "118"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Ezek 3:4\u201311",
+        "second": "Acts 10:34\u201344"
+      },
+      "evening": {
+        "first": "Ezek 34:11\u201316",
+        "second": "John 21:15\u201322"
+      }
+    }
+  },
+  {
+    "day": "Jan 25",
+    "title": "The Conversion of Saint Paul the Apostle",
+    "psalms": {
+      "morning": [
+        "19"
+      ],
+      "evening": [
+        "119:89\u201312"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Isa 45:18\u201325",
+        "second": "Phil 3:4b\u201311"
+      },
+      "evening": {
+        "first": "Sir 39:1\u201310",
+        "second": "Acts 9:1\u201322"
+      }
+    }
+  },
+  {
+    "day": "Feb 1",
+    "title": "Eve of the Presentation",
+    "psalms": {
+      "evening": [
+        "113",
+        "122"
+      ]
+    },
+    "lessons": {
+      "evening": {
+        "first": "1 Sam 1:20\u201328a",
+        "second": "Rom 8:14\u201321"
+      }
+    }
+  },
+  {
+    "day": "Feb 2",
+    "title": "The Presentation of Our Lord Jesus Christ in the Temple",
+    "psalms": {
+      "morning": [
+        "42",
+        "43"
+      ],
+      "evening": [
+        "48",
+        "87"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "1 Sam 2:1\u201310",
+        "second": "John 8:31\u201336"
+      },
+      "evening": {
+        "first": "Hag 2:1\u20139",
+        "second": "1 John 3:1\u20138"
+      }
+    }
+  },
+  {
+    "day": "Feb 24",
+    "title": "Saint Matthias the Apostle",
+    "psalms": {
+      "morning": [
+        "80"
+      ],
+      "evening": [
+        "33"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "1 Sam 16:1\u201313",
+        "second": "1 John 2:18\u201325"
+      },
+      "evening": {
+        "first": "1 Sam 12:1\u20135",
+        "second": "Acts 20:17\u201335"
+      }
+    }
+  },
+  {
+    "day": "Mar 19",
+    "title": "Saint Joseph",
+    "psalms": {
+      "morning": [
+        "132"
+      ],
+      "evening": [
+        "34"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Isa 63:7\u201316",
+        "second": "Matt 1:18\u201325"
+      },
+      "evening": {
+        "first": "2 Chr 6:12\u201317",
+        "second": "Eph 3:14\u201321"
+      }
+    }
+  },
+  {
+    "day": "Mar 24",
+    "title": "Eve of the Annunciation",
+    "psalms": {
+      "evening": [
+        "8",
+        "138"
+      ]
+    },
+    "lessons": {
+      "evening": {
+        "first": "Gen 3:1\u201315",
+        "second": "Eph 3:14\u201321"
+      }
+    }
+  },
+  {
+    "day": "Mar 25",
+    "title": "The Annunciation of Our Lord Jesus Christ to Mary",
+    "psalms": {
+      "morning": [
+        "85",
+        "87"
+      ],
+      "evening": [
+        "110:1\u20135(6\u20137)",
+        "132"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Isa 52:7\u201312",
+        "second": "Heb 2:5\u201310"
+      },
+      "evening": {
+        "first": "Wis 9:1\u201312",
+        "second": "John 1:9\u201314"
+      }
+    }
+  },
+  {
+    "day": "Apr 25",
+    "title": "Saint Mark the Evangelist",
+    "psalms": {
+      "morning": [
+        "145"
+      ],
+      "evening": [
+        "67",
+        "96"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Sir 2:1\u201311",
+        "second": "Acts 12:25\u201313:3"
+      },
+      "evening": {
+        "first": "Isa 62:6\u201312",
+        "second": "2 Tim 4:1\u201311"
+      }
+    }
+  },
+  {
+    "day": "May 1",
+    "title": "Saint Philip and Saint James, Apostles",
+    "psalms": {
+      "morning": [
+        "119:137\u2013160"
+      ],
+      "evening": [
+        "139"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Job 23:1\u201312",
+        "second": "John 1:42\u201351"
+      },
+      "evening": {
+        "first": "Prov 4:7\u20138",
+        "second": "John 12:20\u201326"
+      }
+    }
+  },
+  {
+    "day": "May 30",
+    "title": "Eve of the Visitation",
+    "psalms": {
+      "evening": [
+        "146",
+        "147"
+      ]
+    },
+    "lessons": {
+      "evening": {
+        "first": "Isa 11:1\u201310",
+        "second": "Heb 2:11\u201318"
+      }
+    }
+  },
+  {
+    "day": "May 31",
+    "title": "The Visitation of Mary to Elizabeth",
+    "psalms": {
+      "morning": [
+        "72"
+      ],
+      "evening": [
+        "146",
+        "147"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "1 Sam 1:1\u201320",
+        "second": "Heb 3:1\u20136"
+      },
+      "evening": {
+        "first": "Zech 2:10\u201313",
+        "second": "John 3:25\u201330"
+      }
+    }
+  },
+  {
+    "day": "Jun 11",
+    "title": "Saint Barnabas the Apostle",
+    "psalms": {
+      "morning": [
+        "15",
+        "67"
+      ],
+      "evening": [
+        "19",
+        "146"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Sir 31:3\u201311",
+        "second": "Acts 4:32\u201337"
+      },
+      "evening": {
+        "first": "Job 29:1\u201316",
+        "second": "Acts 9:26\u201331"
+      }
+    }
+  },
+  {
+    "day": "Jun 23",
+    "title": "Eve of Saint John the Baptist",
+    "psalms": {
+      "evening": [
+        "103"
+      ]
+    },
+    "lessons": {
+      "evening": {
+        "first": "Sir 48:1\u201311",
+        "second": "Luke 1:5\u201323"
+      }
+    }
+  },
+  {
+    "day": "Jun 24",
+    "title": "The Nativity of Saint John the Baptist",
+    "psalms": {
+      "morning": [
+        "82",
+        "98"
+      ],
+      "evening": [
+        "80"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Mal 3:1\u20135",
+        "second": "John 3:22\u201330"
+      },
+      "evening": {
+        "first": "Mal 4:1\u20136",
+        "second": "Matt 11:2\u201319"
+      }
+    }
+  },
+  {
+    "day": "Jun 29",
+    "title": "Saint Peter and Saint Paul, Apostles",
+    "psalms": {
+      "morning": [
+        "66"
+      ],
+      "evening": [
+        "97",
+        "138"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Ezek 2:1\u20137",
+        "second": "Acts 11:1\u201318"
+      },
+      "evening": {
+        "first": "Isa 49:1\u20136",
+        "second": "Gal 2:1\u20139"
+      }
+    }
+  },
+  {
+    "day": "Jul 22",
+    "title": "Saint Mary Magdalene",
+    "psalms": {
+      "morning": [
+        "116"
+      ],
+      "evening": [
+        "30",
+        "149"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Zeph 3:14\u201320",
+        "second": "Mark 15:47\u201316:7"
+      },
+      "evening": {
+        "first": "Exod 15:19\u201321",
+        "second": "2 Cor 1:3\u20137"
+      }
+    }
+  },
+  {
+    "day": "Jul 25",
+    "title": "Saint James the Apostle",
+    "psalms": {
+      "morning": [
+        "34"
+      ],
+      "evening": [
+        "33"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Jer 16:14\u201321",
+        "second": "Mark 1:14\u201320"
+      },
+      "evening": {
+        "first": "Jer 26:1\u201315",
+        "second": "Matt 10:16\u201332"
+      }
+    }
+  },
+  {
+    "day": "Aug 5",
+    "title": "Eve of the Transfiguration",
+    "psalms": {
+      "evening": [
+        "84"
+      ]
+    },
+    "lessons": {
+      "evening": {
+        "first": "1 Kings 19:1\u201312",
+        "second": "2 Cor 3:1\u20139, 18"
+      }
+    }
+  },
+  {
+    "day": "Aug 6",
+    "title": "The Transfiguration of Our Lord Jesus Christ",
+    "psalms": {
+      "morning": [
+        "2",
+        "24"
+      ],
+      "evening": [
+        "72"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Exod 24:12\u201318",
+        "second": "2 Cor 4:1\u20136"
+      },
+      "evening": {
+        "first": "Dan 7:9\u201310, 13\u201314",
+        "second": "John 12:27\u201336a"
+      }
+    }
+  },
+  {
+    "day": "Aug 15",
+    "title": "Saint Mary, Mother of Our Lord Jesus Christ",
+    "psalms": {
+      "morning": [
+        "113",
+        "115"
+      ],
+      "evening": [
+        "45",
+        "[138]",
+        "[149]"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "1 Sam 2:1\u201310",
+        "second": "John 2:1\u201312"
+      },
+      "evening": {
+        "first": "Jer 31:1\u201314",
+        "altFirst": "Zech 2:10\u201313",
+        "second": "John 19:23\u201327",
+        "altSecond": "Acts 1:6\u201314"
+      }
+    }
+  },
+  {
+    "day": "Aug 24",
+    "title": "Saint Bartholomew the Apostle",
+    "psalms": {
+      "morning": [
+        "86"
+      ],
+      "evening": [
+        "15",
+        "67"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Gen 28:10\u201317",
+        "second": "John 1:43\u201351"
+      },
+      "evening": {
+        "first": "Isa 66:1\u20132, 18\u201323",
+        "second": "1 Pet 5:1\u201311"
+      }
+    }
+  },
+  {
+    "day": "Sep 13",
+    "title": "Eve of Holy Cross",
+    "psalms": {
+      "evening": [
+        "46",
+        "87"
+      ]
+    },
+    "lessons": {
+      "evening": {
+        "first": "1 Kgs 8:22\u201330",
+        "second": "Eph 2:11\u201322"
+      }
+    }
+  },
+  {
+    "day": "Sep 14",
+    "title": "Holy Cross Day",
+    "psalms": {
+      "morning": [
+        "66"
+      ],
+      "evening": [
+        "118"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Num 21:4\u20139",
+        "second": "John 3:11\u201317"
+      },
+      "evening": {
+        "first": "Gen 3:1\u201315",
+        "second": "1 Pet 3:17\u201322"
+      }
+    }
+  },
+  {
+    "day": "Sep 21",
+    "title": "Saint Matthew, Apostle and Evangelist",
+    "psalms": {
+      "morning": [
+        "119:41\u201364"
+      ],
+      "evening": [
+        "19",
+        "112"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Isa 8:11\u201320",
+        "second": "Rom 10:1\u201315"
+      },
+      "evening": {
+        "first": "Job 28:12\u201328",
+        "second": "Matt 13:44\u201352"
+      }
+    }
+  },
+  {
+    "day": "Sep 29",
+    "title": "Saint Michael and All Angels",
+    "psalms": {
+      "morning": [
+        "8",
+        "148"
+      ],
+      "evening": [
+        "34",
+        "150",
+        "[104]"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Job 38:1\u20137",
+        "second": "Heb 1:1\u201314"
+      },
+      "evening": {
+        "first": "Dan 12:1\u20133",
+        "altFirst": "2 Kgs 6:8\u201317",
+        "second": "Mark 13:21\u201327",
+        "altSecond": "Rev 5:1\u201314"
+      }
+    }
+  },
+  {
+    "day": "Oct 18",
+    "title": "Saint Luke the Evangelist",
+    "psalms": {
+      "morning": [
+        "103"
+      ],
+      "evening": [
+        "67",
+        "96"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Ezek 47:1\u201312",
+        "second": "Luke 1:1\u20134"
+      },
+      "evening": {
+        "first": "Isa 52:7\u201310",
+        "second": "Acts 1:1\u20138"
+      }
+    }
+  },
+  {
+    "day": "Oct 23",
+    "title": "Saint James of Jerusalem, Brother of Our Lord Jesus Christ",
+    "psalms": {
+      "morning": [
+        "119:145\u2013168"
+      ],
+      "evening": [
+        "122",
+        "125"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Jer 11:18\u201323",
+        "second": "Matt 10:16\u201322"
+      },
+      "evening": {
+        "first": "Isa 65:17\u201325",
+        "second": "Heb 12:12\u201324"
+      }
+    }
+  },
+  {
+    "day": "Oct 28",
+    "title": "Saint Simon and Saint Jude, Apostles",
+    "psalms": {
+      "morning": [
+        "66"
+      ],
+      "evening": [
+        "116",
+        "117"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Isa 28:9\u201316",
+        "second": "Eph 4:1\u201316"
+      },
+      "evening": {
+        "first": "Isa 4:2\u20139",
+        "second": "John 14:15\u201331"
+      }
+    }
+  },
+  {
+    "day": "Oct 31",
+    "title": "Eve of All Saints",
+    "psalms": {
+      "evening": [
+        "34"
+      ]
+    },
+    "lessons": {
+      "evening": {
+        "first": "Wis 3:1\u20139",
+        "second": "Rev 19:1, 4\u201310"
+      }
+    }
+  },
+  {
+    "day": "Nov 1",
+    "title": "All Saints' Day",
+    "psalms": {
+      "morning": [
+        "111",
+        "112"
+      ],
+      "evening": [
+        "148",
+        "150"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "2 Esd 2:42\u201347",
+        "second": "Heb 11:32\u201312:2"
+      },
+      "evening": {
+        "first": "Wis 5:1\u20135, 14\u201316",
+        "second": "Rev 21:1\u20134, 22\u201322:5"
+      }
+    }
+  },
+  {
+    "title": "Thanksgiving Day",
+    "psalms": {
+      "morning": [
+        "147"
+      ],
+      "evening": [
+        "145"
+      ]
+    },
+    "lessons": {
+      "morning": {
+        "first": "Deut 26:1\u201311",
+        "second": "John 6:26\u201335"
+      },
+      "evening": {
+        "first": "Joel 2:21\u201327",
+        "second": "1 Thess 5:12\u201324"
+      }
+    }
+  }
 ]


### PR DESCRIPTION
Fixes #5

Three corrections:
1. Saint Andrew: Nov 10 → Nov 30 (feast day)
2. Annuciation → Annunciation typo  
3. Holy Cross Day: Sep 15 → Sep 14 (BCP 1979 date)