### PR TITLE
Fix three data errors in dol-holy-days.json

### DIFF
--- a/json/readings/dol-holy-days.json
+++ b/json/readings/dol-holy-days.json
@@ -1,6 +1,6 @@
 [
 	{
-		"day": "Nov 10",
+		"day": "Nov 30",
 		"title": "Saint Andrew the Apostle",
 		"psalms": {
 			"morning": [
@@ -262,7 +262,7 @@
 	},
 	{
 		"day": "Mar 25",
-		"title": "The Annuciation of Our Lord Jesus Christ to Mary",
+		"title": "The Annunciation of Our Lord Jesus Christ to Mary",
 		"psalms": {
 			"morning": [
 				"85",
@@ -603,7 +603,7 @@
 		}
 	},
 	{
-		"day": "Sep 15",
+		"day": "Sep 14",
 		"title": "Holy Cross Day",
 		"psalms": {
 			"morning": [


### PR DESCRIPTION
Fixes three data errors reported in #5:

1. Saint Andrew feast day: Nov 10 -> Nov 30 (correct date per BCP)
2. Typo in title: "Annuciation" -> "Annunciation"
3. Holy Cross Day: Sep 15 -> Sep 14 (correct date per BCP 1979)

All changes are in json/readings/dol-holy-days.json.